### PR TITLE
Feat: Manual paged search

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ async fn main() -> Result<(), Error> {
         .try_collect()
         .await?;
 
+    // Or handle the pagination manually.
+    let parameters = SearchParameters::empty().and_raw("_count", "10");  // Set page size.
+    let page: Page<Patient> = client.search_paged(PagedSearchMethod::Parameters(parameters)).await?;
+
+    let patients: Vec<Patient> = page.results;
+    match page.next_url {
+        Some(url) => {
+            let new_page: Page<Patient> = client.search_paged(PagedSearchMethod::Url(url)).await?;
+        }
+        None => {
+            println!("No next page");
+        }
+    }
+
     Ok(())
 }
 ```

--- a/crates/fhir-sdk/src/client/mod.rs
+++ b/crates/fhir-sdk/src/client/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
 	builder::ClientBuilder,
 	error::Error,
 	request::RequestSettings,
-	search::SearchParameters,
+	search::{Page, PagedSearchMethod, SearchParameters},
 	write::{AnyResourceWrite, ResourceWrite},
 };
 

--- a/crates/fhir-sdk/src/client/r5/paging.rs
+++ b/crates/fhir-sdk/src/client/r5/paging.rs
@@ -82,7 +82,7 @@ impl Stream for Paged {
 				};
 
 				// Parse the next page's URL or error out.
-				if let Some(next_url_string) = find_next_page_url(&bundle) {
+				if let Some(next_url_string) = find_page_url(&bundle, LinkRelationTypes::Next) {
 					let Ok(next_url) = Url::parse(next_url_string) else {
 						tracing::error!("Could not parse next page URL");
 						return Poll::Ready(Some(Err(Error::UrlParse(next_url_string.clone()))));
@@ -150,14 +150,9 @@ impl Stream for Paged {
 	}
 }
 
-/// Find the URL of the next page of the results returned in the Bundle.
-fn find_next_page_url(bundle: &Bundle) -> Option<&String> {
-	bundle
-		.link
-		.iter()
-		.flatten()
-		.find(|link| link.relation == LinkRelationTypes::Next)
-		.map(|link| &link.url)
+/// Find the URL of the page of the results returned in the Bundle.
+pub(crate) fn find_page_url(bundle: &Bundle, relation_type: LinkRelationTypes) -> Option<&String> {
+	bundle.link.iter().flatten().find(|link| link.relation == relation_type).map(|link| &link.url)
 }
 
 /// Query a resource from a given URL.

--- a/crates/fhir-sdk/src/client/search.rs
+++ b/crates/fhir-sdk/src/client/search.rs
@@ -1,5 +1,33 @@
 //! Search parameter handling.
 
+use crate::Url;
+
+/// Method to use for paged search.
+/// Use Parameters for the initial search, and Url to "follow" previous and next pages.
+pub enum PagedSearchMethod {
+	Parameters(SearchParameters),
+	Url(Url),
+}
+
+/// Single page of a result.
+///
+/// The URLs to previous and next pages are opaque and can be anything.
+/// The client only ensures it access to the same server.
+///
+/// See [search] for details and examples.
+pub struct Page<R> {
+	/// Results matching the search.
+	pub results: Vec<R>,
+	/// The URL to the previous page.
+	pub previous_url: Option<Url>,
+	/// The URL to the next page.
+	pub next_url: Option<Url>,
+	/// Total number of matches, as defined by the server.
+	/// This field is always optional and  behavior for this can be controlled with _total search parameter,
+	/// but the server can ignore it and
+	pub total: Option<u32>,
+}
+
 /// A collection of AND-joined search parameters.
 #[derive(Debug, Default, Clone)]
 pub struct SearchParameters {

--- a/crates/fhir-sdk/src/client/search.rs
+++ b/crates/fhir-sdk/src/client/search.rs
@@ -4,8 +4,11 @@ use crate::Url;
 
 /// Method to use for paged search.
 /// Use Parameters for the initial search, and Url to "follow" previous and next pages.
+#[derive(Debug, Clone)]
 pub enum PagedSearchMethod {
+	/// Search by given parameters, i.e., make the initial request.
 	Parameters(SearchParameters),
+	/// Search by given exact URL, i.e., make follow-up request.
 	Url(Url),
 }
 
@@ -15,6 +18,7 @@ pub enum PagedSearchMethod {
 /// The client only ensures it access to the same server.
 ///
 /// See [search] for details and examples.
+#[derive(Debug, Clone)]
 pub struct Page<R> {
 	/// Results matching the search.
 	pub results: Vec<R>,


### PR DESCRIPTION
Hi
This PR adds feature to handle pagination manually. This is particularly useful for http servers that don't want to keep `Stream`s alive. I tested this with R5 and my infinite scroll functionality, works perfect on my case.

I created as a draft, if you're happy with the approach I'll apply the same for the other `Client` versions and port tests.
Edit: And possibly do the same for `search_all` too?

Closes: https://github.com/FlixCoder/fhir-sdk/issues/34